### PR TITLE
Windows Installation Guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ mkdir -p ~/.config/kn/plugins
 cp kn-operator ~/.config/kn/plugins
 ```
 
+> Note: The plugins directory defaults to `$base_dir/plugins` relative to your [kn config file](https://knative.dev/docs/client/configure-kn/) location.
+>  
+> On Windows, the default plugins directory is in `%APPDATA%\kn\plugins`
+
 Check if plugin is loaded
 
 ```sh


### PR DESCRIPTION
# Changes
- Updated the readme to reflect that the default windows plugin directory is different than the directory provided in the `sh` installation example.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind documentation
